### PR TITLE
Update tar2rpm.sh (fix for file paths that contain empty spaces)

### DIFF
--- a/tar2rpm.sh
+++ b/tar2rpm.sh
@@ -97,7 +97,7 @@ function spec {
             echo "$path"
         done
     done <<< $TARGET
-    while read -ra fileNames; do
+    while IFS= read -ra fileNames; do
         for fileName in "${fileNames[@]}"; do
             echo %attr\($FILEPERM, $FILEUSER, $FILEGROUP\) "$TARGET/$fileName"
         done


### PR DESCRIPTION
fixed bug when filename path was fragmented due to containing empty spaces
