### PR TITLE
Update tar2rpm.sh (fix for bug when file paths contain empty spaces)

### DIFF
--- a/tar2rpm.sh
+++ b/tar2rpm.sh
@@ -97,9 +97,9 @@ function spec {
             echo "$path"
         done
     done <<< $TARGET
-    while read -ra fileNames; do
+    while IFS= read -ra fileNames; do
         for fileName in "${fileNames[@]}"; do
-            echo %attr\($FILEPERM, $FILEUSER, $FILEGROUP\) "$TARGET/$fileName"
+            echo %attr\($FILEPERM, $FILEUSER, $FILEGROUP\) \""$TARGET/${fileName#./}"\"
         done
     done <<< "$(tar -tf $TARFILE)"
 }


### PR DESCRIPTION
fix for bug when fileName containing empty space causes file path to fragment into separate array entries
